### PR TITLE
Feature/vot-130-fix-validation-error-response

### DIFF
--- a/app/app/actions/authActions.js
+++ b/app/app/actions/authActions.js
@@ -7,8 +7,8 @@ import { headers } from "next/headers";
 
 /**
  * Hanldes user register
- * @param {*} prev 
- * @param {*} formData 
+ * @param {*} prev
+ * @param {*} formData
  * @returns {object
  */
 export async function registerUser(prev, formData) {
@@ -27,15 +27,15 @@ export async function registerUser(prev, formData) {
     });
     data = true;
   } catch (err) {
-    error = err.response?.data?.Message;
+    error = err.response?.data?.errors;
   }
   return { data, error };
 }
 
 /**
  * Hanles user log in
- * @param {*} prev 
- * @param {*} formData 
+ * @param {*} prev
+ * @param {*} formData
  * @returns {object}
  */
 export async function loginUser(prev, formData) {
@@ -47,7 +47,7 @@ export async function loginUser(prev, formData) {
     const response = await axiosAuth.post("login", {
       ...fData,
     });
-  
+
     setCookie("session", {
       accessToken: response.data.accessToken,
       accessTokenExpiration: response.data.accessTokenExpiration,
@@ -55,7 +55,7 @@ export async function loginUser(prev, formData) {
     });
     data = true;
   } catch (err) {
-    error = err.response?.data?.Message;
+    error = err.response?.data?.message;
   }
 
   return { data, error };
@@ -63,7 +63,7 @@ export async function loginUser(prev, formData) {
 
 /**
  * Handles googles log in.
- * @param {*} resp 
+ * @param {*} resp
  * @returns {object}
  */
 export async function externalLoginUser(resp) {
@@ -81,7 +81,7 @@ export async function externalLoginUser(resp) {
     });
     respData.data = true;
   } catch (err) {
-    respData.error = err.response?.data?.Message;
+    respData.error = err.response?.data?.message;
   }
   return respData;
 }
@@ -111,7 +111,7 @@ export async function logoutUser() {
 
     redirect("/");
   } catch (err) {
-    error = err.response?.data?.Message;
+    error = err.response?.data?.message;
   }
   return { error };
 }
@@ -130,14 +130,14 @@ export async function getUserSession() {
  * @returns {undefined | string}
  */
 export async function validateToken() {
-  const session = getCookie('session');
+  const session = getCookie("session");
 
-  if (session === null || (Date.now() < session?.accessTokenExpiration)) {
+  if (session === null || Date.now() < session?.accessTokenExpiration) {
     return;
   }
 
   try {
-    const response = await axiosAuth.post('refresh', {
+    const response = await axiosAuth.post("refresh", {
       refreshToken: session.refreshToken,
     });
 
@@ -147,6 +147,6 @@ export async function validateToken() {
       refreshToken: response.data.refreshToken,
     });
   } catch (err) {
-    return {error: err.response.data.Message};
+    return { error: err.response.data.message };
   }
 }

--- a/app/app/components/RegisterForm/RegisterForm.jsx
+++ b/app/app/components/RegisterForm/RegisterForm.jsx
@@ -33,11 +33,11 @@ const RegisterForm = ({ userId }) => {
       redirect("/");
     } else {
       if (typeof formState.error === "object") {
-        setErrors({ ...formState.error.errors });
-      } else if (formState.error){
+        setErrors({ ...formState.error });
+      } else if (formState.error) {
         setErrors((state) => ({ ...state, Email: formState.error }));
       } else {
-        if (formState !== '') {
+        if (formState !== "") {
           console.log(formState);
         }
       }


### PR DESCRIPTION
In register i changed the err object to be err.response?.data?.errors;
On every other action we don't have validation errors so we just take the message err.response?.data?.message;
Standartized the error responses they will always be the same structure with camelCase properties.
{
  "errorId": "784283ea-40ee-4c87-be74-0c456cc7518d",
  "statusCode": 400,
  "message": "Email or password is incorrect!",
  "type": "https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.1",
  "errors": {
    "Error": "Email or password is incorrect!"
  }
}