### PR TITLE
add logic to delete session cookie if the refresh token is expired

### DIFF
--- a/app/app/actions/authActions.js
+++ b/app/app/actions/authActions.js
@@ -147,6 +147,7 @@ export async function validateToken() {
       refreshToken: response.data.refreshToken,
     });
   } catch (err) {
+    deleteCookie("session");
     return { error: err.response?.data?.message };
   }
 }


### PR DESCRIPTION
Change logic, to delete session cookie when refresh token is invalid. It will redirect to the home page only the first time. 